### PR TITLE
Fix LoD level selection when using Rviz's TopDownOrtho ViewController

### DIFF
--- a/libraries/wavemap/include/wavemap/integrator/projection_model/impl/spherical_projector_inl.h
+++ b/libraries/wavemap/include/wavemap/integrator/projection_model/impl/spherical_projector_inl.h
@@ -9,7 +9,7 @@ namespace wavemap {
 inline SensorCoordinates SphericalProjector::cartesianToSensor(
     const Point3D& C_point) const {
   ImageCoordinates image_coordinates = cartesianToImage(C_point);
-  const FloatingPoint range = C_point.norm();
+  const FloatingPoint range = cartesianToSensorZ(C_point);
   return {std::move(image_coordinates), range};
 }
 

--- a/ros/wavemap_rviz_plugin/include/wavemap_rviz_plugin/visuals/voxel_visual.h
+++ b/ros/wavemap_rviz_plugin/include/wavemap_rviz_plugin/visuals/voxel_visual.h
@@ -114,10 +114,11 @@ class VoxelVisual : public QObject {
   float lod_update_distance_threshold_ = 0.1f;
   Ogre::Vector3 camera_position_at_last_lod_update_{};
   bool force_lod_update_ = true;
-  void updateLOD(const Point3D& camera_position);
+  void updateLOD(const Ogre::Camera& active_camera);
   static NdtreeIndexElement computeRecommendedBlockLodHeight(
-      FloatingPoint distance_to_cam, FloatingPoint min_cell_width,
-      NdtreeIndexElement min_height, NdtreeIndexElement max_height);
+      const Ogre::Camera& active_camera, const OctreeIndex& block_index,
+      FloatingPoint min_cell_width, NdtreeIndexElement min_height,
+      NdtreeIndexElement max_height);
   std::optional<NdtreeIndexElement> getCurrentBlockLodHeight(
       IndexElement map_tree_height, const Index3D& block_idx);
 


### PR DESCRIPTION
# Description

This PR fixes a bug that causes the map to only be rendered at the lowest resolution in Rviz when using the TopDownOrtho ViewController. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Detailed summary

Wavemap's Rviz plugin uses LoD rendering to improve Rviz's framerate and responsiveness when drawing large maps. The LoD level for each block in the map is chosen based on its distance to the camera. 

However, in TopDownOrtho mode, the scene is rendered without perspective (orthographic projection), and Rviz sets the z-coordinate of the camera to a dummy value (500m). This, in turn, caused our plugin to think all blocks are very far away and always pick the coarsest LoD level.

The fix in this PR detects when the projection mode is orthographic, and if so, always uses the highest LoD level.

In the long term, we could reintroduce rendering optimizations for TopDownOrtho mode (e.g. frustum and occlusion culling). This will be done in a future development cycle for the Rviz plugin.

Fixes #51 

# Testing

The fix was successfully tested on:
- [x] Integrated graphics (laptop)
- [x] GPU machine (desktop)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any required changes in dependencies have been committed and pushed
