### PR TITLE
devcontainer: Use bash, add bashrc

### DIFF
--- a/.devcontainer/vscode/Dockerfile
+++ b/.devcontainer/vscode/Dockerfile
@@ -7,7 +7,8 @@ ARG USERNAME=ci
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME && \
-    useradd --uid $USER_UID --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash $USERNAME && \
+    cp -a /etc/skel/.bashrc /home/$USERNAME/ && \
     chown -R $USERNAME:$USERNAME /home/$USERNAME && \
     echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
     chmod 0440 /etc/sudoers.d/$USERNAME


### PR DESCRIPTION
# Description

Specifies bash as console and adds the bashrc file. This adds a lot of convenient console features such as tab completion and colors 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [x] Other (please describe): Vscode devcontainer convenience

## Detailed Summary

- On user creation, specify bash as console
- Copy the skeleton .bashrc to the home folder of the created user

The only thing I don't fully understand is why the .bashrc is not copied automatically, but this can happen if the base image is a very minimal image